### PR TITLE
few fixes

### DIFF
--- a/designTemplate/src/main/java/com/lge/qcircle/template/QCircleBackButton.java
+++ b/designTemplate/src/main/java/com/lge/qcircle/template/QCircleBackButton.java
@@ -1,16 +1,13 @@
 package com.lge.qcircle.template;
 
 import android.app.Activity;
-import android.content.ContentResolver;
 import android.content.Context;
 import android.graphics.Color;
-import android.provider.Settings;
 import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.ImageView;
-import android.widget.ImageView.ScaleType;
 import android.widget.RelativeLayout;
 
 import com.lge.qcircle.utils.QCircleFeature;
@@ -20,46 +17,95 @@ import com.lge.qcircle.utils.QCircleFeature;
  *
  * @author jeongeun.jeon
  */
-public final class QCircleBackButton extends QCircleTemplateElement{
+public final class QCircleBackButton extends QCircleTemplateElement {
 
-    private final String TAG = "QCircleBackButton";
+	private final String TAG = "QCircleBackButton";
 	private OnClickListener mListener;
 	private ImageView mBtnContent = null;
-	private int		mButtonHeight = 0;
+	private int mButtonHeight = 0;
 	private boolean isDark = false;
 
-
-
 	private static float PADDING_RATIO = 0.35f;
-    //sujin.cho
-    private final float fixedButtonRatio = 0.23f;
-    private RelativeLayout.LayoutParams mParams = null;
+	//sujin.cho
+	private final float fixedButtonRatio = 0.23f;
+	private RelativeLayout.LayoutParams mParams = null;
 
-    // layout values
-    private static int mFullSize = 0; // circle diameter
+	// layout values
+	private static int mFullSize = 0; // circle diameter
 
+	/**
+	 * creates a back button.
+	 *
+	 * @param context {@code Activity} which has a circle view.<br>
+	 *                <b>If it is null, you might get errors when you use method of this class.</b>
+	 */
+	public QCircleBackButton(Context context) {
+		mContext = context;
+		getTemplateDiameter(context);
+		mButtonHeight = (int) (fixedButtonRatio * mFullSize);
+		if (!setButton())
+			Log.d(TAG, "Cannot create a button. Context is null.");
+	}
 
-    /**
-     * creates a back button.
-     *
-     * @param context {@code Activity} which has a circle view.<br>
-     * <b>If it is null, you might get errors when you use method of this class.</b>
-     */
-    public QCircleBackButton(Context context) {
-        mContext = context;
-        getTemplateDiameter(context);
-        mButtonHeight = (int)(fixedButtonRatio * mFullSize);
-        if (!setButton())
-            Log.d(TAG, "Cannot create a button. Context is null.");
-    }
+	/**
+	 * creates a back button.
+	 *
+	 * @param context  {@code Activity} which has a circle view.<br>
+	 * @param listener Listener on click
+	 *                 <b>If it is null, you might get errors when you use method of this class.</b>
+	 */
+	public QCircleBackButton(Context context, OnClickListener listener) {
+		this(context);
+		mListener = listener;
+	}
 
+	/**
+	 * creates a back button.
+	 *
+	 * @param context       {@code Activity} which has a circle view.<br>
+	 * @param theme         Theme for button
+	 * @param isTransparent is the button transparent
+	 *                      <p/>
+	 *                      <b>If it is null, you might get errors when you use method of this class.</b>
+	 */
+	public QCircleBackButton(Context context, ButtonTheme theme, boolean isTransparent, OnClickListener listener) {
+		this(context, theme, isTransparent);
+		mListener = listener;
+	}
+
+	/**
+	 * creates a back button.
+	 *
+	 * @param context       {@code Activity} which has a circle view.<br>
+	 * @param theme         Theme for button
+	 * @param isTransparent is the button transparent
+	 *                      <p/>
+	 *                      <b>If it is null, you might get errors when you use method of this class.</b>
+	 */
+	public QCircleBackButton(Context context, ButtonTheme theme, boolean isTransparent) {
+		this(context, theme);
+		if (isTransparent) setBackgroundTransparent();
+	}
+
+	/**
+	 * creates a back button.
+	 *
+	 * @param context {@code Activity} which has a circle view.<br>
+	 * @param theme   Theme for button
+	 *                <p/>
+	 *                <b>If it is null, you might get errors when you use method of this class.</b>
+	 */
+	public QCircleBackButton(Context context, ButtonTheme theme) {
+		this(context);
+		setTheme(theme);
+	}
 	/**
 	 * creates a back button.
 	 *
 	 * @param context {@code Activity} which has a circle view.<br>
 	 * <b>If it is null, you might get errors when you use method of this class.</b>
 	 */
-    /*
+	/*
 	public QCircleBackButton(Context context, float heightRatio) {
 
         mContext = context;
@@ -74,8 +120,8 @@ public final class QCircleBackButton extends QCircleTemplateElement{
 	/**
 	 * creates a back button.
 	 *
-	 * @param context {@code Activity} which has a circle view.<br>
-	 * <b>If it is null, you might get errors when you use method of this class.</b>
+	 * @param context  {@code Activity} which has a circle view.<br>
+	 *                 <b>If it is null, you might get errors when you use method of this class.</b>
 	 * @param listener Listener on click
 	 */
 	public QCircleBackButton(Context context, int height, OnClickListener listener) {
@@ -96,10 +142,10 @@ public final class QCircleBackButton extends QCircleTemplateElement{
 		boolean result = false;
 		if (mContext != null) {
 			mBtnContent = new ImageView(mContext);
-			mBtnContent.setPadding(0,(int)(mButtonHeight*PADDING_RATIO), 0, (int)(mButtonHeight*PADDING_RATIO));
+			mBtnContent.setPadding(0, (int) (mButtonHeight * PADDING_RATIO), 0, (int) (mButtonHeight * PADDING_RATIO));
 			// set attributes
 			mBtnContent.setId(R.id.backButton);
-            initTheme();
+			initTheme();
 			mBtnContent.setOnClickListener(new OnClickListener() {
 				@Override
 				public void onClick(View v) {
@@ -118,47 +164,46 @@ public final class QCircleBackButton extends QCircleTemplateElement{
 		return result;
 	}
 
-    /**
-     * sets theme of the back button.
-     * @author Yoav Sternberg
-     */
+	/**
+	 * sets theme of the back button.
+	 *
+	 * @author Yoav Sternberg
+	 */
 	private void initTheme() {
 		mBtnContent.setImageResource(isDark ? R.drawable.backover_dark : R.drawable.backover);
 		mBtnContent.setBackgroundResource(isDark ? R.drawable.back_button_background_dark : R.drawable.back_button_background);
 	}
 
-    /**
-     * Uses dark theme for the back button.<P>
-     *
-     * @param isDark  flag which indicates whether dark theme is used or not.
-     * @author Yoav Sternberg
-     * @deprecated
-     */
+	/**
+	 * Uses dark theme for the back button.<P>
+	 *
+	 * @param isDark flag which indicates whether dark theme is used or not.
+	 * @author Yoav Sternberg
+	 * @deprecated
+	 */
 	public void isDark(boolean isDark) {
 		this.isDark = isDark;
-        initTheme();
+		initTheme();
 	}
 
-    /**
-     * Sets a theme for the back button. This provides three types of themes.
-     *
-     * @param type
-     */
-    public void setTheme(ButtonTheme type)
-    {
-        if(mBtnContent != null) {
-            if (type == ButtonTheme.DARK) {
-                mBtnContent.setImageResource(R.drawable.backover_dark);
-                mBtnContent.setBackgroundResource(R.drawable.back_button_background_dark);
-            } else if (type == ButtonTheme.LIGHT) {
-                mBtnContent.setImageResource(R.drawable.backover);
-                mBtnContent.setBackgroundResource(R.drawable.back_button_background);
-            } else if (type == ButtonTheme.TRANSPARENT) {
-                mBtnContent.setBackgroundColor(Color.TRANSPARENT);
-            }
-        }
-    }
-
+	/**
+	 * Sets a theme for the back button. This provides three types of themes.
+	 *
+	 * @param type
+	 */
+	public void setTheme(ButtonTheme type) {
+		if (mBtnContent != null) {
+			if (type == ButtonTheme.DARK) {
+				mBtnContent.setImageResource(R.drawable.backover_dark);
+				mBtnContent.setBackgroundResource(R.drawable.back_button_background_dark);
+			} else if (type == ButtonTheme.LIGHT) {
+				mBtnContent.setImageResource(R.drawable.backover);
+				mBtnContent.setBackgroundResource(R.drawable.back_button_background);
+			} else if (type == ButtonTheme.TRANSPARENT) {
+				mBtnContent.setBackgroundColor(Color.TRANSPARENT);
+			}
+		}
+	}
 
 	/**
 	 * Gets the view of the button.
@@ -186,60 +231,55 @@ public final class QCircleBackButton extends QCircleTemplateElement{
 			mBtnContent.setBackgroundResource(R.drawable.back_button_background_semi_transparent);
 	}
 
-    /**
-     * Adds this to the template.
-     * @param parent
-     * @author sujin.cho
-     */
-    @Override
-    protected void addTo(RelativeLayout parent, RelativeLayout content) {
-        if ((mBtnContent != null) && (parent != null)) {
-            setLayoutParams();
-            parent.addView(mBtnContent);
-            adjustLayout(content);
-        }
-    }
+	/**
+	 * Adds this to the template.
+	 *
+	 * @param parent
+	 * @author sujin.cho
+	 */
+	@Override
+	protected void addTo(RelativeLayout parent, RelativeLayout content) {
+		if ((mBtnContent != null) && (parent != null)) {
+			setLayoutParams();
+			parent.addView(mBtnContent);
+			adjustLayout(content);
+		}
+	}
 
-    private void adjustLayout(RelativeLayout content)
-    {
-        RelativeLayout.LayoutParams contentParams = (RelativeLayout.LayoutParams) content.getLayoutParams();
-        contentParams.addRule(RelativeLayout.ABOVE, mBtnContent.getId());
-        content.setLayoutParams(contentParams);
-    }
+	private void adjustLayout(RelativeLayout content) {
+		RelativeLayout.LayoutParams contentParams = (RelativeLayout.LayoutParams) content.getLayoutParams();
+		contentParams.addRule(RelativeLayout.ABOVE, mBtnContent.getId());
+		content.setLayoutParams(contentParams);
+	}
 
-    /**
-     * sets layout parameters of the back button.
-     *
-     */
-    private void setLayoutParams()
-    {
-        int buttonAreaHeight = (int)(mFullSize * fixedButtonRatio);
-        // add a button into the bottom of the circle layout
-        mParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT,buttonAreaHeight);
-        mParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, 1);
-        mBtnContent.setLayoutParams(mParams);
-    }
+	/**
+	 * sets layout parameters of the back button.
+	 */
+	private void setLayoutParams() {
+		int buttonAreaHeight = (int) (mFullSize * fixedButtonRatio);
+		// add a button into the bottom of the circle layout
+		mParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, buttonAreaHeight);
+		mParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, 1);
+		mBtnContent.setLayoutParams(mParams);
+	}
 
-    /**
-     * locates the circle on the correct position. The correct position depends on phone model.
-     * <p>
-     * @author sujin.cho
-     */
-    private void getTemplateDiameter(Context context)
-    {
-        if(context != null) {
-            if (!QCircleFeature.isQuickCircleAvailable(context)) {
-                Log.i(TAG, "Quick Circle case is not available");
-                return;
-            }
-            // circle size
-            int id = context.getResources().getIdentifier(
-                    "config_circle_diameter", "dimen", "com.lge.internal");
-            mFullSize = context.getResources().getDimensionPixelSize(id);
-        }
-        else
-        {
-
-        }
-    }
+	/**
+	 * locates the circle on the correct position. The correct position depends on phone model.
+	 * <p/>
+	 *
+	 * @author sujin.cho
+	 */
+	private void getTemplateDiameter(Context context) {
+		if (context != null) {
+			if (!QCircleFeature.isQuickCircleAvailable(context)) {
+				Log.i(TAG, "Quick Circle case is not available");
+				return;
+			}
+			// circle size
+			int id = context.getResources().getIdentifier(
+					"config_circle_diameter", "dimen", "com.lge.internal");
+			mFullSize = context.getResources().getDimensionPixelSize(id);
+		} else {
+		}
+	}
 }

--- a/designTemplate/src/main/java/com/lge/qcircle/template/QCircleDialog.java
+++ b/designTemplate/src/main/java/com/lge/qcircle/template/QCircleDialog.java
@@ -9,7 +9,6 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import com.lge.qcircle.template.QCircleTitle;
 
 /**
  * The {@code QCircleDialog} class provides a Dialog for Quick Circle.<P>
@@ -24,7 +23,7 @@ public class QCircleDialog {
 	QCircleTemplate activityTemplate;
 	// Dialog properties
 	String title;
-	String text;
+	CharSequence text;
 	String positiveButtonText;
 	String negativeButtonText;
 	Drawable image;
@@ -56,7 +55,7 @@ public class QCircleDialog {
 	 */
 	public static class Builder {
 		private String title = null;
-		private String text;
+		private CharSequence text;
 		private String positiveButtonText;
 		private String negativeButtonText;
 		private Drawable image = null;
@@ -64,8 +63,8 @@ public class QCircleDialog {
 		private View.OnClickListener negativeButtonListener = null;
 		private DialogMode mode = DialogMode.Ok;
 
-        //sujin.cho
-        private QCircleTitle mTitle = null;
+		//sujin.cho
+		private QCircleTitle mTitle = null;
 
 		/**
 		 * sets title of the Dialog.<P>
@@ -84,7 +83,7 @@ public class QCircleDialog {
 		 * @param text main text. It will be displayed on the middle of the dialog.
 		 * @return a Builder with main text
 		 */
-		public Builder setText(String text) {
+		public Builder setText(CharSequence text) {
 			this.text = text;
 			return this;
 		}
@@ -138,8 +137,9 @@ public class QCircleDialog {
 		 *
 		 * @param positiveButtonText text for positive button
 		 */
-		public void setPositiveButtonText(String positiveButtonText) {
+		public Builder setPositiveButtonText(String positiveButtonText) {
 			this.positiveButtonText = positiveButtonText;
+			return this;
 		}
 
 		/**
@@ -147,8 +147,9 @@ public class QCircleDialog {
 		 *
 		 * @param negativeButtonText text for negative button
 		 */
-		public void setNegativeButtonText(String negativeButtonText) {
+		public Builder setNegativeButtonText(String negativeButtonText) {
 			this.negativeButtonText = negativeButtonText;
+			return this;
 		}
 
 		/**
@@ -173,9 +174,10 @@ public class QCircleDialog {
 		this.activityTemplate = activityTemplate;
 		RelativeLayout layout = (RelativeLayout) activityTemplate.getLayoutById(TemplateTag.CONTENT).getParent();
 		final QCircleTemplate template = new QCircleTemplate(activity);
-		//template.setTitle(title == null ? "" : title, Color.WHITE, activity.getResources().getColor(
-		//		mode == DialogMode.Error ? R.color.dialog_title_background_color_error : R.color.dialog_title_background_color_regular));
-		//template.setTitleTextSize(17);
+		QCircleTitle qCircleTitle = new QCircleTitle(activity, title == null ? "" : title, Color.WHITE,
+				activity.getResources().getColor(mode == DialogMode.Error ? R.color.dialog_title_background_color_error : R.color.dialog_title_background_color_regular));
+		qCircleTitle.setTextSize(17f);
+		template.addElement(qCircleTitle);
 		RelativeLayout dialogLayout = (RelativeLayout) activity.getLayoutInflater()
 				.inflate(mode == DialogMode.YesNo ? R.layout.qcircle_dialog_layout_yes_no : R.layout.qcircle_dialog_layout, layout, false);
 		if (text != null) {

--- a/designTemplate/src/main/java/com/lge/qcircle/template/QCircleTemplate.java
+++ b/designTemplate/src/main/java/com/lge/qcircle/template/QCircleTemplate.java
@@ -23,7 +23,7 @@ import com.lge.qcircle.utils.QCircleFeature;
 
 /**
  * The {@code QCircleTemplate} class provides design templates for LG QuickCircle.
- * <p>
+ * <p/>
  * There are 5 templates: <br>
  * <ul>
  * <li>empty content</li>
@@ -34,7 +34,7 @@ import com.lge.qcircle.utils.QCircleFeature;
  * </ul>
  * In order to get the layout, see {@link com.lge.qcircle.template.TemplateType}.<br>
  * In addition, you can add a title or a back button into each layout described above.
- * <p>
+ * <p/>
  * This class supports APIs for setting layout, changing attributes of Views in the layout, and
  * setting fullscreen intent.
  *
@@ -50,8 +50,7 @@ public class QCircleTemplate {
 	protected static final String EXTRA_ACCESSORY_COVER_STATE = "com.lge.intent.extra.ACCESSORY_COVER_STATE";
 	protected static final String ACTION_ACCESSORY_COVER_EVENT = "com.lge.android.intent.action.ACCESSORY_COVER_EVENT";
 
-
-    // strings for special devices
+	// strings for special devices
 	protected static final String DEVICE_G3 = "g3";
 	protected static final String DEVICE_T6 = "tiger6";
 
@@ -70,19 +69,18 @@ public class QCircleTemplate {
 	protected QCircleTitle mTitle = null;
 
 	// layout values
-    private static int mFullSize = 0; // circle diameter
-    private static int mTopOffset = 0; // top offset of circle
-    private static int mYpos = 0;
+	private static int mFullSize = 0; // circle diameter
+	private static int mTopOffset = 0; // top offset of circle
+	private static int mYpos = 0;
 
-    /**
-    @deprecated
-     */
+	/**
+	 * @deprecated
+	 */
 	private final float fixedButtonRatio = 0.23f; // Button height ratio
-    /**
-     @deprecated
-     */
+	/**
+	 * @deprecated
+	 */
 	private final float fixedTitleRatio = 0.23f; // Title height ratio
-
 
 	/**
 	 * creates a template with an empty content.
@@ -158,7 +156,7 @@ public class QCircleTemplate {
 
 	/**
 	 * gets the root view of the template layout.
-	 * <p>
+	 * <p/>
 	 *
 	 * @return root view of the layout.
 	 */
@@ -168,53 +166,40 @@ public class QCircleTemplate {
 	}
 
 	/**
-     * @deprecated
-	 * sets a title.
-	 * <p>
-	 * It creates a title bar on the top of the layout.
-	 * <p>
-	 * Note that this method does not create a title bar when the title bar already exists. It
-	 * changes the text of the existing title bar.
-	 *
 	 * @param title text for the title. <br>
 	 *              If it is null, no title text will be shown but the title bar will occupy some
 	 *              space.
+	 * @deprecated sets a title.
+	 * <p/>
+	 * It creates a title bar on the top of the layout.
+	 * <p/>
+	 * Note that this method does not create a title bar when the title bar already exists. It
+	 * changes the text of the existing title bar.
 	 */
 	public void setTitle(String title) {
 		setTitle(title, fixedTitleRatio);
 	}
 
 	/**
-     * @deprecated
-	 * sets a title with the given height ratio.
-	 * <p>
-	 * It creates a title bar on the top of the layout. The height of the title bar depends on
-	 * {@code heightRatio}.
-	 * <p>
-	 * Note that this method does not create a title bar when the title bar already exists. It
-	 * changes the text and the height of the existing title bar.
-	 *
 	 * @param title       text for the title. <br>
 	 *                    If it is null, no title text will be shown but the title bar will occupy some
 	 *                    space.
 	 * @param heightRatio ratio of the title bar. <br>
 	 *                    If it is less or equal to 0, the height ratio of the title bar will be 0.2 of
 	 *                    QuickCircle diameter.
+	 * @deprecated sets a title with the given height ratio.
+	 * <p/>
+	 * It creates a title bar on the top of the layout. The height of the title bar depends on
+	 * {@code heightRatio}.
+	 * <p/>
+	 * Note that this method does not create a title bar when the title bar already exists. It
+	 * changes the text and the height of the existing title bar.
 	 */
 	public void setTitle(String title, float heightRatio) {
 		setTitle(title, heightRatio, Color.BLACK, Color.TRANSPARENT);
 	}
 
 	/**
-     * @deprecated
-	 * sets a title with the given height ratio and the given title color and background color.
-	 * <p>
-	 * It creates a title bar on the top of the layout. The height of the title bar depends on
-	 * {@code heightRatio}.
-	 * <p>
-	 * Note that this method does not create a title bar when the title bar already exists. It
-	 * changes the text and the height of the existing title bar.
-	 *
 	 * @param title           text for the title. <br>
 	 *                        If it is null, no title text will be shown but the title bar will occupy some
 	 *                        space.
@@ -223,6 +208,13 @@ public class QCircleTemplate {
 	 *                        QuickCircle diameter.
 	 * @param textColor       The color of the title
 	 * @param backgroundColor The background color of the title
+	 * @deprecated sets a title with the given height ratio and the given title color and background color.
+	 * <p/>
+	 * It creates a title bar on the top of the layout. The height of the title bar depends on
+	 * {@code heightRatio}.
+	 * <p/>
+	 * Note that this method does not create a title bar when the title bar already exists. It
+	 * changes the text and the height of the existing title bar.
 	 */
 	public void setTitle(String title, float heightRatio, int textColor, int backgroundColor) {
 		if (mTitle == null) {
@@ -239,42 +231,36 @@ public class QCircleTemplate {
 		}
 	}
 
-
 	/**
-     * @deprecated
-	 * sets a title with the default height ratio and the given title color and background color.
-	 * <p>
-	 * It creates a title bar on the top of the layout. The height of the title bar depends on
-	 * {@code heightRatio}.
-	 * <p>
-	 * Note that this method does not create a title bar when the title bar already exists. It
-	 * changes the text and the height of the existing title bar.
-	 *
 	 * @param title           text for the title. <br>
 	 *                        If it is null, no title text will be shown but the title bar will occupy some
 	 *                        space.
 	 * @param textColor       The color of the title
 	 * @param backgroundColor The background color of the title
+	 * @deprecated sets a title with the default height ratio and the given title color and background color.
+	 * <p/>
+	 * It creates a title bar on the top of the layout. The height of the title bar depends on
+	 * {@code heightRatio}.
+	 * <p/>
+	 * Note that this method does not create a title bar when the title bar already exists. It
+	 * changes the text and the height of the existing title bar.
 	 */
 	public void setTitle(String title, int textColor, int backgroundColor) {
 		setTitle(title, fixedTitleRatio, textColor, backgroundColor);
 	}
 
-
 	/**
-     * @deprecated
-	 * sets a title as the given view with the given height ratio.
-	 * <p>
-	 * It creates a title bar on the top of the layout. The content of the title bar is
-	 * {@code titleView} and the height of the title bar depends on {@code heightRatio}.
-	 * <p>
-	 * Note that this method does not create a title bar when the title bar already exists. It
-	 * changes the content and the view of the existing title bar.
-	 *
 	 * @param titleView   View to be a title
 	 * @param heightRatio ratio of the title bar. <br>
 	 *                    If it is less or equal to 0, the height ratio of the title bar will be 0.2 of
 	 *                    QuickCircle diameter.
+	 * @deprecated sets a title as the given view with the given height ratio.
+	 * <p/>
+	 * It creates a title bar on the top of the layout. The content of the title bar is
+	 * {@code titleView} and the height of the title bar depends on {@code heightRatio}.
+	 * <p/>
+	 * Note that this method does not create a title bar when the title bar already exists. It
+	 * changes the content and the view of the existing title bar.
 	 */
 	public void setTitle(View titleView, float heightRatio) {
 		if (mTitle == null) { // create a Title
@@ -295,13 +281,11 @@ public class QCircleTemplate {
 		}
 	}
 
-
 	/**
-     * @deprecated
-	 * sets a back button.
-	 * <p>
+	 * @deprecated sets a back button.
+	 * <p/>
 	 * It creates a back button on the bottom of the layout.
-	 * <p>
+	 * <p/>
 	 * You do not need to implement an {@code onClickListener} for the button, because it already
 	 * has one.<br>
 	 * Note that this method does not create a button when the button already exists.
@@ -310,23 +294,21 @@ public class QCircleTemplate {
 		setBackButton(null);
 	}
 
-
 	/**
-     * @deprecated
-	 * sets a back button with callback.
-	 * <p>
+	 * @param onClickListener Callback for back button.
+	 *                        <b>should be used for closing objects, like camera</b>
+	 * @deprecated sets a back button with callback.
+	 * <p/>
 	 * It creates a back button on the bottom of the layout.
-	 * <p>
+	 * <p/>
 	 * You do not need to implement an {@code onClickListener} for the button, because it already
 	 * has one.<br>
 	 * Note that this method does not create a button when the button already exists.
-	 * @param onClickListener Callback for back button.
-	 *                        <b>should be used for closing objects, like camera</b>
 	 */
 	public void setBackButton(View.OnClickListener onClickListener) {
 		if (mBackButton == null) {
 			if (mContext != null)
-				mBackButton = new QCircleBackButton(mContext, (int)(mFullSize * fixedButtonRatio), onClickListener);
+				mBackButton = new QCircleBackButton(mContext, (int) (mFullSize * fixedButtonRatio), onClickListener);
 			else {
 				Log.e(TAG, "Cannot create the back button: context is null");
 				return;
@@ -335,12 +317,10 @@ public class QCircleTemplate {
 		}
 	}
 
-
 	/**
-     * @deprecated
-	 * Set the theme to the back button. Default is light.
 	 * @param isDark Is dark theme
-     * @author Yoav Sternberg
+	 * @author Yoav Sternberg
+	 * @deprecated Set the theme to the back button. Default is light.
 	 */
 	public void setBackButtonTheme(boolean isDark) {
 		if (mBackButton != null) {
@@ -350,7 +330,7 @@ public class QCircleTemplate {
 
 	/**
 	 * gets a layout with the given id.
-	 * <p>
+	 * <p/>
 	 * This method is useful when you want to add or modify Views of the template.<br>
 	 * Every content or sidebar is a {@code RelativeLayout}.
 	 *
@@ -368,7 +348,7 @@ public class QCircleTemplate {
 
 	/**
 	 * changes the ratio of the first sidebar.
-	 * <p>
+	 * <p/>
 	 * Some design templates have sidebars which is re-sizable. Note that only the first sidebar can
 	 * be re-sized even if the template has more than 1 sidebars.<br>
 	 * This method changes the size of the first sidebar with the ratio comparing to the full
@@ -419,17 +399,15 @@ public class QCircleTemplate {
 	}
 
 	/**
-     * @deprecated
-	 * sets the background of the template as the given image.
-	 * <p>
-	 * The background affects all the layouts including a title bar and a back button.
-	 *
 	 * @param image              background image
 	 * @param overwiteButtonArea flag for clear background of the back button if it exists.<br>
 	 *                           The default background of a back button is light gray. You should clear the
 	 *                           background color of a back button when you want to use full-layout background.<br>
 	 *                           Set this flag in that case.
 	 * @see #setBackgroundColor(int, boolean)
+	 * @deprecated sets the background of the template as the given image.
+	 * <p/>
+	 * The background affects all the layouts including a title bar and a back button.
 	 */
 	public void setBackgroundDrawable(Drawable image, boolean overwiteButtonArea) {
 		if (mCircleLayout != null)
@@ -440,59 +418,54 @@ public class QCircleTemplate {
 		// mTitle.setBackgroundTransparent();
 	}
 
-    /**
-     * sets the background of the template as the given image.
-     * <p>
-     * The background affects all the layouts including a title bar and a back button.
-     *
-     * @param image              background image
-     * @see #setBackgroundColor(int, boolean)
-     */
-    public void setBackgroundDrawable(Drawable image) {
-        if (mCircleLayout != null)
-            mCircleLayout.setBackground(image);
-    }
-
 	/**
-     * @deprecated
-     * sets the background of the template as the given color.
-     * <p>
-     * The background affects all the layouts including a title bar and a back button.
-     *
-     * @param color              background color
-     * @param overwiteButtonArea flag for clear background of the back button if it exists.<br>
-     *                           The default background of a back button is light gray. You should clear the
-     *                           background color of a back button when you want to use full-layout background.<br>
-     *                           Set this flag in that case.
-     * @see #setBackgroundDrawable(android.graphics.drawable.Drawable, boolean)
-     */
-    public void setBackgroundColor(int color, boolean overwiteButtonArea) {
-        if (mCircleLayout != null)
-            mCircleLayout.setBackgroundColor(color);
-        if (overwiteButtonArea && mBackButton != null)
-            mBackButton.setBackgroundTransparent();
-    }
-
-    /**
-     * sets the background of the template as the given color.
-     * <p>
-     * The background affects all the layouts including a title bar and a back button.
-     *
-     * @param color              background color
-     * @see #setBackgroundDrawable(android.graphics.drawable.Drawable, boolean)
-     */
-    public void setBackgroundColor(int color) {
-        if (mCircleLayout != null)
-            mCircleLayout.setBackgroundColor(color);
-    }
-
-
-	/**
-     * @deprecated
-	 * sets the font size of the title.
-	 * <p>
+	 * sets the background of the template as the given image.
+	 * <p/>
+	 * The background affects all the layouts including a title bar and a back button.
 	 *
+	 * @param image background image
+	 * @see #setBackgroundColor(int, boolean)
+	 */
+	public void setBackgroundDrawable(Drawable image) {
+		if (mCircleLayout != null)
+			mCircleLayout.setBackground(image);
+	}
+
+	/**
+	 * @param color              background color
+	 * @param overwiteButtonArea flag for clear background of the back button if it exists.<br>
+	 *                           The default background of a back button is light gray. You should clear the
+	 *                           background color of a back button when you want to use full-layout background.<br>
+	 *                           Set this flag in that case.
+	 * @see #setBackgroundDrawable(android.graphics.drawable.Drawable, boolean)
+	 * @deprecated sets the background of the template as the given color.
+	 * <p/>
+	 * The background affects all the layouts including a title bar and a back button.
+	 */
+	public void setBackgroundColor(int color, boolean overwiteButtonArea) {
+		if (mCircleLayout != null)
+			mCircleLayout.setBackgroundColor(color);
+		if (overwiteButtonArea && mBackButton != null)
+			mBackButton.setBackgroundTransparent();
+	}
+
+	/**
+	 * sets the background of the template as the given color.
+	 * <p/>
+	 * The background affects all the layouts including a title bar and a back button.
+	 *
+	 * @param color background color
+	 * @see #setBackgroundDrawable(android.graphics.drawable.Drawable, boolean)
+	 */
+	public void setBackgroundColor(int color) {
+		if (mCircleLayout != null)
+			mCircleLayout.setBackgroundColor(color);
+	}
+
+	/**
 	 * @param size font size in pixel
+	 * @deprecated sets the font size of the title.
+	 * <p/>
 	 */
 	public void setTitleTextSize(float size) {
 		if (mTitle != null) {
@@ -502,7 +475,7 @@ public class QCircleTemplate {
 
 	/**
 	 * initializes the layout of the circle window.
-	 * <p>
+	 * <p/>
 	 * It loads a template layout from the xml file and retrieves the root view (actually a
 	 * {@code FrameLayout} and the content view(a {@code RelativeLayout}).
 	 *
@@ -520,12 +493,11 @@ public class QCircleTemplate {
 		}
 	}
 
-    /**
-     * @deprecated
-     * changes the height of the title.<P>
-     * If there is no title bar on the layout, no happens.
-     * @param heightRatio ratio of the title bar.
-     */
+	/**
+	 * @param heightRatio ratio of the title bar.
+	 * @deprecated changes the height of the title.<P>
+	 * If there is no title bar on the layout, no happens.
+	 */
 	private void changeTitleViewHeight(float heightRatio) {
 		if (mTitle != null) {
 			if (heightRatio <= 0) // adjust the height
@@ -540,19 +512,16 @@ public class QCircleTemplate {
 		}
 	}
 
-
 	/**
-     * @deprecated
-	 * adds a title view to the layout.
-	 * <p>
-	 * It is called by {@link #setTitle(String)} to adjust the circle layout. The title view is
-	 * added on the top of the layout and the content window will be on the below of the title view.
-	 *
 	 * @param titleView   title view to be added. <br>
 	 *                    If it is null, the circle layout will not change.
 	 * @param heightRatio ratio of the title bar. <br>
 	 *                    If it is less or equal to 0, the height ratio of the title bar will be 0.2 of
 	 *                    QuickCircle diameter.
+	 * @deprecated adds a title view to the layout.
+	 * <p/>
+	 * It is called by {@link #setTitle(String)} to adjust the circle layout. The title view is
+	 * added on the top of the layout and the content window will be on the below of the title view.
 	 */
 	private void addTitleView(QCircleTitle titleView, float heightRatio) {
 		if (mCircleLayout != null) {
@@ -568,17 +537,14 @@ public class QCircleTemplate {
 		}
 	}
 
-
 	/**
-     * @deprecated
-	 * adds a button view to the layout.
-	 * <p>
+	 * @param buttonView button view to be added. <br>
+	 *                   If it is null, the circle layout will not change.
+	 * @deprecated adds a button view to the layout.
+	 * <p/>
 	 * It is called by {@link com.lge.qcircle.template.QCircleTemplate#setBackButton()} to adjust the circle layout. The
 	 * button view is added on the bottom of the layout and the content window will be on the top of
 	 * the button view.
-	 *
-	 * @param buttonView button view to be added. <br>
-	 *                   If it is null, the circle layout will not change.
 	 */
 	private void addBackButtonView(QCircleBackButton buttonView) {
 		if (mCircleLayout != null) {
@@ -593,9 +559,8 @@ public class QCircleTemplate {
 	}
 
 	/**
-     * @deprecated
-	 * adjust the circle layout when a title view or a button view is added.
-	 * <p>
+	 * @deprecated adjust the circle layout when a title view or a button view is added.
+	 * <p/>
 	 * It is called by {@link #addBackButtonView(QCircleBackButton)).
 	 * It changes the relative position of the content window.
 	 */
@@ -616,14 +581,12 @@ public class QCircleTemplate {
 
 	/**
 	 * locates the circle on the correct position. The correct position depends on phone model.
-	 * <p>
+	 * <p/>
 	 */
 	protected void setCircleLayout() {
-
 		// 1. get circle size and Y offset
 		// circle size
-        initCircleLayoutParam();
-
+		initCircleLayoutParam();
 		// 2. adjust the circle layout for the model
 		FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(mFullSize, mFullSize);
 		// circle image
@@ -650,43 +613,39 @@ public class QCircleTemplate {
 		}
 	}
 
-    /**
-     * locates the circle on the correct position. The correct position depends on phone model.
-     * <p>
-     * @author sujin.cho
-     */
-    private boolean initCircleLayoutParam()
-    {
-        if(!QCircleFeature.isQuickCircleAvailable(mContext)){
-            Log.i(TAG, "Quick Circle case is not available");
-            return false;
-        }
+	/**
+	 * locates the circle on the correct position. The correct position depends on phone model.
+	 * <p/>
+	 *
+	 * @author sujin.cho
+	 */
+	private boolean initCircleLayoutParam() {
+		if (!QCircleFeature.isQuickCircleAvailable(mContext)) {
+			Log.i(TAG, "Quick Circle case is not available");
+			return false;
+		}
+		// circle size
+		int id = mContext.getResources().getIdentifier(
+				"config_circle_diameter", "dimen", "com.lge.internal");
+		mFullSize = mContext.getResources().getDimensionPixelSize(id);
+		// y position (in G3, y position = y offset)
+		id = mContext.getResources().getIdentifier(
+				"config_circle_window_y_pos", "dimen", "com.lge.internal");
+		mYpos = mContext.getResources().getDimensionPixelSize(id);
+		// adjust Y offset for the model
+		id = mContext.getResources().getIdentifier(
+				"config_circle_window_height", "dimen", "com.lge.internal");
+		int height = mContext.getResources().getDimensionPixelSize(id);
+		mTopOffset = mYpos + ((height - mFullSize) / 2);
+		return true;
+	}
 
-        // circle size
-        int id = mContext.getResources().getIdentifier(
-                "config_circle_diameter", "dimen", "com.lge.internal");
-        mFullSize = mContext.getResources().getDimensionPixelSize(id);
-        // y position (in G3, y position = y offset)
-        id = mContext.getResources().getIdentifier(
-                "config_circle_window_y_pos", "dimen", "com.lge.internal");
-        mYpos = mContext.getResources().getDimensionPixelSize(id);
-        // adjust Y offset for the model
-        id = mContext.getResources().getIdentifier(
-                "config_circle_window_height", "dimen", "com.lge.internal");
-        int height = mContext.getResources().getDimensionPixelSize(id);
-        mTopOffset = mYpos + ((height - mFullSize) / 2);
-
-        return true;
-    }
-
-
-
-        /**
-         * sets the design template.
-         * <p>
-         *
-         * @param type design template type to be set
-         */
+	/**
+	 * sets the design template.
+	 * <p/>
+	 *
+	 * @param type design template type to be set
+	 */
 	protected void setTemplateType(TemplateType type) {
 		mLayoutType = type;
 		if (mContext != null) {
@@ -725,68 +684,67 @@ public class QCircleTemplate {
 
 	/**
 	 * registers cover event broadcasts.
-	 * <p>
+	 * <p/>
 	 * The a cover-closed event will make the circle shown and a cover-opened event will make the
 	 * circle hidden after you invoke this method. The full screen intent will starts if you set a
 	 * fullscreen intent by calling {@link #setFullscreenIntent(android.content.Intent)}.
 	 */
 	public void registerIntentReceiver() {
-        if( mContext != null ) {
-            mReceiver = new BroadcastReceiver() {
+		if (mContext != null) {
+			mReceiver = new BroadcastReceiver() {
 
-                @Override
-                public void onReceive(Context context, Intent intent) {
-                    // Log.d(TAG, "onReceive: " + intent.getAction());
-                    String action = intent.getAction();
-                    if (action == null) {
-                        return;
-                    }
-
-                    if(!QCircleFeature.isQuickCircleAvailable(mContext)){
-                        Log.i(TAG, "Quick Circle case is not available");
-                        return;
-                    }
-
-                    // Receives a LG QCirle intent for the cover event
-                    if (ACTION_ACCESSORY_COVER_EVENT.equals(action)) {
-                        // Gets the current state of the cover
-                        int quickCoverState = intent.getIntExtra(EXTRA_ACCESSORY_COVER_STATE,
-                                EXTRA_ACCESSORY_COVER_OPENED);
-                        if (quickCoverState == EXTRA_ACCESSORY_COVER_CLOSED) { // closed
-                            //setQuickCircleWindowParam();
-                        } else if (quickCoverState == EXTRA_ACCESSORY_COVER_OPENED) { // opened
-                            if (mFullscreenIntent != null && mContext != null) {
-                                mContext.startActivity(mFullscreenIntent);
-                            } else if (mContent != null && mAsyncCreator != null) {
-                                Intent launching = mAsyncCreator.getIntent();
-                                if (launching != null) {
-                                    try {
-                                        mContext.startActivity(launching);
-                                    } catch (ActivityNotFoundException e) {
-                                        // Package does not exist, ignore.
-                                        e.printStackTrace();
-                                    }
-                                }
-                            }
-                            if (mContext instanceof Activity) {
-                                ((Activity) mContext).finish();
-                            }
-                        }
-                    }
-                }
-            };
-            IntentFilter filter = new IntentFilter();
-            filter.addAction(ACTION_ACCESSORY_COVER_EVENT);
-            // Register a broadcast receiver with the system
-            mContext.registerReceiver(mReceiver, filter);
-        }
+				@Override
+				public void onReceive(Context context, Intent intent) {
+					// Log.d(TAG, "onReceive: " + intent.getAction());
+					String action = intent.getAction();
+					if (action == null) {
+						return;
+					}
+					if (!QCircleFeature.isQuickCircleAvailable(mContext)) {
+						Log.i(TAG, "Quick Circle case is not available");
+						return;
+					}
+					// Receives a LG QCirle intent for the cover event
+					if (ACTION_ACCESSORY_COVER_EVENT.equals(action)) {
+						// Gets the current state of the cover
+						int quickCoverState = intent.getIntExtra(EXTRA_ACCESSORY_COVER_STATE,
+								EXTRA_ACCESSORY_COVER_OPENED);
+						if (quickCoverState == EXTRA_ACCESSORY_COVER_CLOSED) { // closed
+							//setQuickCircleWindowParam();
+						} else if (quickCoverState == EXTRA_ACCESSORY_COVER_OPENED) { // opened
+							if (mFullscreenIntent != null && mContext != null) {
+								mContext.startActivity(mFullscreenIntent);
+							} else if (mContent != null && mAsyncCreator != null) {
+								Intent launching = mAsyncCreator.getIntent();
+								if (launching != null) {
+									try {
+										mContext.startActivity(launching);
+									} catch (ActivityNotFoundException e) {
+										// Package does not exist, ignore.
+										e.printStackTrace();
+									}
+								}
+							}
+							if (mContext instanceof Activity) {
+								((Activity) mContext).finish();
+							}
+						}
+					}
+				}
+			};
+			IntentFilter filter = new IntentFilter();
+			filter.addAction(ACTION_ACCESSORY_COVER_EVENT);
+			// Register a broadcast receiver with the system
+			mContext.registerReceiver(mReceiver, filter);
+		}
 	}
 
-    /**
-     * un-registers a default broadcast receiver.<P>
-     * It must be called when {@link #registerIntentReceiver) has been called.
-     * @author Yoav Sternberg
-     */
+	/**
+	 * un-registers a default broadcast receiver.<P>
+	 * It must be called when {@link #registerIntentReceiver) has been called.
+	 *
+	 * @author Yoav Sternberg
+	 */
 	public void unregisterReceiver() {
 		try {
 			mContext.unregisterReceiver(mReceiver);
@@ -800,16 +758,16 @@ public class QCircleTemplate {
 	 */
 	private void setQuickCircleWindowParam() {
 		if (mContext != null && mContext instanceof Activity) {
-
-            //only for Activity extends Activity. does not work for ActionBarActivity....
-            ((Activity) mContext).requestWindowFeature(Window.FEATURE_NO_TITLE);
+			//only for Activity extends Activity. does not work for ActionBarActivity....
+			if (!((Activity) mContext).getWindow().hasFeature(Window.FEATURE_NO_TITLE))
+				((Activity) mContext).requestWindowFeature(Window.FEATURE_NO_TITLE);
 			Window win = ((Activity) mContext).getWindow();
 			if (win != null) {
 				// Show the sample application view on top
 				win.addFlags(WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED
-						| WindowManager.LayoutParams.FLAG_FULLSCREEN
-						| WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
-                );
+								| WindowManager.LayoutParams.FLAG_FULLSCREEN
+								| WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON
+				);
 			}
 		}
 	}
@@ -842,7 +800,7 @@ public class QCircleTemplate {
 
 	/**
 	 * loads external layout created by users (or user).
-	 * <p>
+	 * <p/>
 	 *
 	 * @param templateId ID of layout. <br>
 	 *                   It should be larger than 0.
@@ -862,50 +820,50 @@ public class QCircleTemplate {
 		}
 	}
 
-    /**
-     * @author Yoav Sternberg
-     */
+	/**
+	 * @author Yoav Sternberg
+	 */
 	public static interface IntentCreatorAsync {
 		Intent getIntent();
 	}
 
-    /**
-     * Adds a UI element to a template.
-     *
-     * @param element UI element.
-     *                The element should extend QCricleTemplateElement abstract class.
-     *
-     * @author sujin.cho
-     */
-    public void addElement(QCircleTemplateElement element)
-    {
-        element.addTo(mCircleLayout, mContent);
-        //remove it later....
-        if(element instanceof QCircleBackButton) mBackButton = (QCircleBackButton)element;
-        else if(element instanceof QCircleTitle) mTitle = (QCircleTitle)element;
-    }
+	/**
+	 * Adds a UI element to a template.
+	 *
+	 * @param element UI element.
+	 *                The element should extend QCricleTemplateElement abstract class.
+	 * @author sujin.cho
+	 */
+	public void addElement(QCircleTemplateElement element) {
+		element.addTo(mCircleLayout, mContent);
+		//remove it later....
+		if (element instanceof QCircleBackButton) mBackButton = (QCircleBackButton) element;
+		else if (element instanceof QCircleTitle) mTitle = (QCircleTitle) element;
+	}
 
-    /**
-     * Returns a diameter of the Quick Circle. This can be used to fit a layout in the Quick Circle window.
-     * @return diameter if the "config_circle_diameter" has a value.
-     * -1 if the "config_circle_diameter" is not loaded.
-     */
-    public int getDiameter() {
-        if(mFullSize == 0) {
-            if(initCircleLayoutParam() != true) return -1;
-        }
-        return mFullSize;
-    }
+	/**
+	 * Returns a diameter of the Quick Circle. This can be used to fit a layout in the Quick Circle window.
+	 *
+	 * @return diameter if the "config_circle_diameter" has a value.
+	 * -1 if the "config_circle_diameter" is not loaded.
+	 */
+	public int getDiameter() {
+		if (mFullSize == 0) {
+			if (initCircleLayoutParam() != true) return -1;
+		}
+		return mFullSize;
+	}
 
-    /**
-     * Returns a vertical position of the Quick Circle from the top. This can be used to properly locate a layout in the Quick Circle window.
-     * @return a position from the top if required configs have values.
-     * -1 if required configs are not loaded.
-     */
-    public int getYpos() {
-        if(mTopOffset == 0) {
-            if(initCircleLayoutParam() != true) return -1;
-        }
-        return mTopOffset;
-    }
+	/**
+	 * Returns a vertical position of the Quick Circle from the top. This can be used to properly locate a layout in the Quick Circle window.
+	 *
+	 * @return a position from the top if required configs have values.
+	 * -1 if required configs are not loaded.
+	 */
+	public int getYpos() {
+		if (mTopOffset == 0) {
+			if (initCircleLayoutParam() != true) return -1;
+		}
+		return mTopOffset;
+	}
 }

--- a/designTemplate/src/main/java/com/lge/qcircle/template/QCircleTitle.java
+++ b/designTemplate/src/main/java/com/lge/qcircle/template/QCircleTitle.java
@@ -17,23 +17,23 @@ import com.lge.qcircle.utils.QCircleFeature;
  *
  * @author jeongeun.jeon
  */
-public final class QCircleTitle extends QCircleTemplateElement{
+public final class QCircleTitle extends QCircleTemplateElement {
 
-    private final String TAG = "QCircleTitle";
+	private final String TAG = "QCircleTitle";
 
 	private LinearLayout mRootView = null;
 	private TextView mTitleView = null;
 
-    //sujin.cho
-    private RelativeLayout.LayoutParams mParams = null;
-    private final float fixedTitleRatio = 0.23f; // Title height ratio
-    private static int mFullSize = 0; // circle diameter
+	//sujin.cho
+	private RelativeLayout.LayoutParams mParams = null;
+	private final float fixedTitleRatio = 0.23f; // Title height ratio
+	private static int mFullSize = 0; // circle diameter
 
-    private boolean useDefaultHeight = true;
+	private boolean useDefaultHeight = true;
 
 	/**
 	 * creates a title bar with a text.
-	 * <p>
+	 * <p/>
 	 * It makes a {@link android.widget.TextView} with the given text.
 	 *
 	 * @param title   title text for the title. <br>
@@ -46,12 +46,9 @@ public final class QCircleTitle extends QCircleTemplateElement{
 		this(context, title, Color.BLACK, Color.TRANSPARENT);
 	}
 
-
-
-
-    /**
+	/**
 	 * creates a title bar with a text.
-	 * <p>
+	 * <p/>
 	 * It makes a {@link android.widget.TextView} with the given text.
 	 *
 	 * @param title           title text for the title. <br>
@@ -64,6 +61,25 @@ public final class QCircleTitle extends QCircleTemplateElement{
 	 */
 	public QCircleTitle(Context context, String title, int titleTextColor, int backgroundColor) {
 		this(context, createTextView(context, title, titleTextColor), backgroundColor);
+	}
+
+	/**
+	 * creates a title bar with a text.
+	 * <p/>
+	 * It makes a {@link android.widget.TextView} with the given text.
+	 *
+	 * @param title           title text for the title. <br>
+	 *                        If it is null, no title text will be shown but the title bar will occupy some
+	 *                        space.
+	 * @param context         {@code Activity} which has a circle view.<br>
+	 *                        If it is null, you might get errors when you use method of this class.
+	 * @param titleTextColor  The color of the title
+	 * @param backgroundColor The background color of the title
+	 * @param textSize        The text size
+	 */
+	public QCircleTitle(Context context, String title, int titleTextColor, int backgroundColor, float textSize) {
+		this(context, title, titleTextColor, backgroundColor);
+		setTextSize(textSize);
 	}
 
 	/**
@@ -90,7 +106,7 @@ public final class QCircleTitle extends QCircleTemplateElement{
 	public QCircleTitle(Context context, View title, int backgroundColor) {
 		if (context != null) {
 			mContext = context;
-            getTemplateDiameter(context);
+			getTemplateDiameter(context);
 			mRootView = createRootView(context, backgroundColor);
 			if (title != null) {
 				if (title instanceof TextView) mTitleView = (TextView) title;
@@ -164,31 +180,31 @@ public final class QCircleTitle extends QCircleTemplateElement{
 		}
 	}
 
-    /**
-     * Changes a background color of title view.
-     * @param color  The background color.  If 0, no background. Currently must be black, with any desired alpha level.
-     * @author sujin.cho
-     */
-    public void setBackgroundColor(int color)
-    {
-        if(mRootView != null)
-            mRootView.setBackgroundColor(color);
-    }
+	/**
+	 * Changes a background color of title view.
+	 *
+	 * @param color The background color.  If 0, no background. Currently must be black, with any desired alpha level.
+	 * @author sujin.cho
+	 */
+	public void setBackgroundColor(int color) {
+		if (mRootView != null)
+			mRootView.setBackgroundColor(color);
+	}
 
-    /**
-     * Changes a text color
-     * @param color The font color.  If 0, no background. Currently must be black, with any desired alpha level.
-     * @author sujin.cho
-     */
-    public void setTextColor(int color)
-    {
-        if(mTitleView != null)
-            mTitleView.setTextColor(color);
-    }
+	/**
+	 * Changes a text color
+	 *
+	 * @param color The font color.  If 0, no background. Currently must be black, with any desired alpha level.
+	 * @author sujin.cho
+	 */
+	public void setTextColor(int color) {
+		if (mTitleView != null)
+			mTitleView.setTextColor(color);
+	}
 
 	/**
 	 * Creates a root layout with a transparent background.
-	 * <p>
+	 * <p/>
 	 * The root layout will include all of contents for a title bar.
 	 *
 	 * @param context Activity which has this title bar
@@ -200,7 +216,7 @@ public final class QCircleTitle extends QCircleTemplateElement{
 
 	/**
 	 * Creates a root layout.
-	 * <p>
+	 * <p/>
 	 * The root layout will include all of contents for a title bar.
 	 *
 	 * @param context         Activity which has this title bar
@@ -248,81 +264,70 @@ public final class QCircleTitle extends QCircleTemplateElement{
 		return text;
 	}
 
-    /**
-     * Adds a title view to parent
-     * <p>
-     * This method is called in QCircleTemplate. First, the methods sets layout parameters for the title.
-     * Next, the method adds the title to parent. Once the title is added, UIs in the parent needs to be adjusted for the new component.
-     *
-     * @param parent QCircle Layout which
-     *
-     * @author sujin.cho
-     */
-    @Override
-    protected void addTo(RelativeLayout parent, RelativeLayout content) {
+	/**
+	 * Adds a title view to parent
+	 * <p/>
+	 * This method is called in QCircleTemplate. First, the methods sets layout parameters for the title.
+	 * Next, the method adds the title to parent. Once the title is added, UIs in the parent needs to be adjusted for the new component.
+	 *
+	 * @param parent QCircle Layout which
+	 * @author sujin.cho
+	 */
+	@Override
+	protected void addTo(RelativeLayout parent, RelativeLayout content) {
+		if ((mRootView != null) && (parent != null)) {
+			if (useDefaultHeight) {
+				setLayoutParams(fixedTitleRatio);
+			}
+			parent.addView(mRootView);
+			adjustLayout(content);
+		}
+	}
 
-        if((mRootView != null) && (parent != null)) {
+	private void adjustLayout(RelativeLayout content) {
+		if (content != null) {
+			RelativeLayout.LayoutParams contentParams = new RelativeLayout.LayoutParams(
+					content.getLayoutParams().width, content.getLayoutParams().height);
+			contentParams.addRule(RelativeLayout.BELOW, mRootView.getId());
+			content.setLayoutParams(contentParams);
+		}
+	}
 
-            if(useDefaultHeight == true) {
-                setLayoutParams(fixedTitleRatio);
-            }
-            parent.addView(mRootView);
-            adjustLayout(content);
-        }
-    }
+	private void setLayoutParams(float heightRatio) {
+		int titleAreaHeight = (int) (mFullSize * heightRatio);
+		mParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, titleAreaHeight);
+		mParams.addRule(RelativeLayout.ALIGN_PARENT_TOP, 1);
+		mRootView.setLayoutParams(mParams);
+	}
 
-    private void adjustLayout(RelativeLayout content)
-    {
-        if(content != null) {
-            RelativeLayout.LayoutParams contentParams = new RelativeLayout.LayoutParams(
-                    content.getLayoutParams().width, content.getLayoutParams().height);
-            contentParams.addRule(RelativeLayout.BELOW, mRootView.getId());
-            content.setLayoutParams(contentParams);
-        }
-    }
+	/**
+	 * Changes a height of title view.
+	 *
+	 * @param heightRatio ratio of the portion of title area respect to the circle diameter.
+	 * @author sujin..cho
+	 */
+	public void setTitleHeight(float heightRatio) {
+		useDefaultHeight = false;
+		setLayoutParams(heightRatio);
+	}
 
-
-    private void setLayoutParams(float heightRatio)
-    {
-        int titleAreaHeight = (int)(mFullSize * heightRatio);
-        mParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, titleAreaHeight);
-        mParams.addRule(RelativeLayout.ALIGN_PARENT_TOP, 1);
-        mRootView.setLayoutParams(mParams);
-    }
-
-
-    /**
-    * Changes a height of title view.
-    * @param heightRatio ratio of the portion of title area respect to the circle diameter.
-    * @author sujin..cho
-    */
-    public void setTitleHeight(float heightRatio)
-    {
-        useDefaultHeight = false;
-        setLayoutParams(heightRatio);
-    }
-
-
-    /**
-     * Locates the circle on the correct position. The correct position depends on phone model.
-     * <p>
-     * @author sujin.cho
-     */
-    private void getTemplateDiameter(Context context)
-    {
-        if(context != null) {
-            if (!QCircleFeature.isQuickCircleAvailable(context)) {
-                Log.i(TAG, "Quick Circle case is not available");
-                return;
-            }
-            // circle size
-            int id = context.getResources().getIdentifier(
-                    "config_circle_diameter", "dimen", "com.lge.internal");
-            mFullSize = context.getResources().getDimensionPixelSize(id);
-        }
-        else
-        {
-
-        }
-    }
+	/**
+	 * Locates the circle on the correct position. The correct position depends on phone model.
+	 * <p/>
+	 *
+	 * @author sujin.cho
+	 */
+	private void getTemplateDiameter(Context context) {
+		if (context != null) {
+			if (!QCircleFeature.isQuickCircleAvailable(context)) {
+				Log.i(TAG, "Quick Circle case is not available");
+				return;
+			}
+			// circle size
+			int id = context.getResources().getIdentifier(
+					"config_circle_diameter", "dimen", "com.lge.internal");
+			mFullSize = context.getResources().getDimensionPixelSize(id);
+		} else {
+		}
+	}
 }


### PR DESCRIPTION
* add constructors to `QCircleBackButton` and `QCircleTitle` for allowing one linear `template.addElement(). close #16.  
* QDialog: close #15
* crash fix for QCircleTemplate + QCircleDialog
* auto indention with Intellij (sorry, it is the last version before the version that follows the current spacing mode)

Note: not compatible with #13
